### PR TITLE
Update class-wc-gateway-payfast.php

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -1352,7 +1352,7 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 	public function display_order_fee( $order_id ) {
 		
 		$order = wc_get_order( $order_id );
-		$fee = get_post_meta( $order->ID, 'payfast_amount_fee', TRUE);
+		$fee = get_post_meta( $order->get_id(), 'payfast_amount_fee', TRUE);
 		
 		if (! $fee ) {
 			return;
@@ -1381,7 +1381,7 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 	public function display_order_net( $order_id ) {
 		
 		$order = wc_get_order( $order_id );
-		$net = get_post_meta( $order->ID, 'payfast_amount_net', TRUE);
+		$net = get_post_meta( $order->get_id(), 'payfast_amount_net', TRUE);
 		
 		if (! $net ) {
 			return;


### PR DESCRIPTION
Fixed debug notice: "Notice: ID was called incorrectly. Order properties should not be accessed directly."

Changed ID retrieval to use function : $order->get_id()